### PR TITLE
Fix offline numpy installation

### DIFF
--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -1,20 +1,29 @@
 import subprocess
 import sys
 import platform
+import os
 
 REQUIREMENTS = "requirements.txt"
 OFFLINE_PACKAGES_DIR = "offline_preparation/python_packages/unified"
 
+
 def get_numpy_wheel():
     system = platform.system().lower()
     machine = platform.machine().lower()
-    
+
     if system == "windows":
         return f"{OFFLINE_PACKAGES_DIR}/numpy-2.2.6-cp313-cp313-win_amd64.whl"
     elif system == "linux":
         if "x86_64" in machine:
             return f"{OFFLINE_PACKAGES_DIR}/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
     return None
+
+
+def get_numpy_source():
+    """Return the path to the NumPy source archive as a fallback."""
+    tarball = "numpy-2.2.6.tar.gz"
+    return tarball if os.path.exists(tarball) else None
+
 
 if __name__ == "__main__":
     try:
@@ -30,9 +39,9 @@ if __name__ == "__main__":
             ]
         )
 
-        # Install NumPy from wheel
+        # Install NumPy from wheel or source archive
         numpy_wheel = get_numpy_wheel()
-        if numpy_wheel:
+        if numpy_wheel and os.path.exists(numpy_wheel):
             subprocess.check_call(
                 [
                     sys.executable,
@@ -44,7 +53,20 @@ if __name__ == "__main__":
             )
             print("[OK] NumPy installed from local wheel.")
         else:
-            print("[WARNING] No compatible NumPy wheel found for your system.")
+            numpy_src = get_numpy_source()
+            if numpy_src:
+                subprocess.check_call(
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        numpy_src,
+                    ]
+                )
+                print("[OK] NumPy installed from source archive.")
+            else:
+                print("[WARNING] No compatible NumPy package found.")
 
         # Install other dependencies
         subprocess.check_call(
@@ -59,15 +81,9 @@ if __name__ == "__main__":
         )
 
         # Install specific package versions
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "fastapi==0.115.12"]
-        )
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "pydantic==2.10.6"]
-        )
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "reflex==0.7.12"]
-        )
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "fastapi==0.115.12"])
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "pydantic==2.10.6"])
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "reflex==0.7.12"])
         print("[OK] Dependencies installed.")
     except Exception as e:
         print(f"[ERROR] {e}")


### PR DESCRIPTION
## Summary
- fallback to source tarball if platform-specific wheel missing in `install_dependencies.py`

## Testing
- `ruff format install_dependencies.py`
- `ruff check install_dependencies.py`
- `black install_dependencies.py`
- `mypy install_dependencies.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684045b337d88328880661378303d96e