### PR TITLE
Improve metrics with request tracking

### DIFF
--- a/palantir/api/metrics.py
+++ b/palantir/api/metrics.py
@@ -1,37 +1,39 @@
-from fastapi import APIRouter, Response
 import os
-import psutil
-from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 from datetime import datetime
 
+import psutil
+from fastapi import APIRouter, Response
+from prometheus_client import CONTENT_TYPE_LATEST
+
+from palantir.core.metrics import get_metrics
+
 router = APIRouter()
+
 
 @router.get("/metrics")
 def metrics():
     cpu_percent = psutil.cpu_percent()
     memory_percent = psutil.virtual_memory().percent
+    business = get_metrics()
+    business["last_updated"] = datetime.now().isoformat()
     return {
         "system": {
             "cpu": cpu_percent,
             "cpu_percent": cpu_percent,
             "memory": memory_percent,
             "memory_percent": memory_percent,
-            "disk_usage": psutil.disk_usage('/').percent
+            "disk_usage": psutil.disk_usage("/").percent,
         },
-        "business": {
-            "active_users": 0,  # TODO: 실제 사용자 수 추적 구현
-            "total_requests": 0,  # TODO: 요청 수 추적 구현
-            "success_rate": 100.0,  # TODO: 성공률 추적 구현
-            "last_updated": datetime.now().isoformat()
-        }
+        "business": business,
     }
+
 
 @router.get("/metrics/self_improve")
 def self_improve_metrics():
     metrics_file = "logs/self_improve_metrics.prom"
     if not os.path.exists(metrics_file):
         return Response(status_code=204)
-    
+
     with open(metrics_file, "r") as f:
         content = f.read()
-    return Response(content=content, media_type=CONTENT_TYPE_LATEST) 
+    return Response(content=content, media_type=CONTENT_TYPE_LATEST)

--- a/palantir/core/metrics.py
+++ b/palantir/core/metrics.py
@@ -1,0 +1,41 @@
+from typing import Optional, Set
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+# Simple in-memory metrics storage
+_total_requests: int = 0
+_successful_requests: int = 0
+_active_tokens: Set[str] = set()
+
+
+def record_request(success: bool, token: Optional[str] = None) -> None:
+    global _total_requests, _successful_requests
+    _total_requests += 1
+    if success:
+        _successful_requests += 1
+    if token:
+        _active_tokens.add(token)
+
+
+def get_metrics() -> dict:
+    success_rate = (
+        (_successful_requests / _total_requests * 100) if _total_requests else 0.0
+    )
+    return {
+        "active_users": len(_active_tokens),
+        "total_requests": _total_requests,
+        "success_rate": round(success_rate, 2),
+    }
+
+
+class RequestMetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        token = request.headers.get("Authorization")
+        if token and token.lower().startswith("bearer "):
+            token = token.split()[1]
+        else:
+            token = None
+        record_request(response.status_code < 500, token)
+        return response

--- a/palantir/core/monitoring.py
+++ b/palantir/core/monitoring.py
@@ -1,2 +1,6 @@
+from .metrics import RequestMetricsMiddleware
+
+
 def setup_monitoring(app):
-    pass 
+    """Attach monitoring middlewares to the FastAPI app."""
+    app.add_middleware(RequestMetricsMiddleware)

--- a/tests/unit/test_metrics_status.py
+++ b/tests/unit/test_metrics_status.py
@@ -12,6 +12,15 @@ def test_metrics_endpoint_status():
     assert r.status_code in (200, 404)
 
 
+def test_metrics_fields():
+    client = TestClient(app)
+    r = client.get("/metrics")
+    if r.status_code == 200:
+        data = r.json()
+        assert "business" in data
+        assert "active_users" in data["business"]
+
+
 def test_metrics_self_improve_204(tmp_path, monkeypatch):
     client = TestClient(app)
     monkeypatch.setattr(os.path, "exists", lambda path: False)


### PR DESCRIPTION
## Summary
- add in-memory request metrics middleware
- expose active user and request counters via `/metrics`
- update monitoring setup to enable middleware
- test metrics fields

## Testing
- `ruff check palantir/core/metrics.py palantir/api/metrics.py palantir/core/monitoring.py tests/unit/test_metrics_status.py --fix`
- `black palantir/core/metrics.py palantir/api/metrics.py palantir/core/monitoring.py tests/unit/test_metrics_status.py`
- `mypy palantir/core/metrics.py palantir/api/metrics.py palantir/core/monitoring.py tests/unit/test_metrics_status.py --config-file mypy.ini` *(fails: palantir/core/llm_manager.py:43: error: "None" has no attribute "chat" [attr-defined])* 
- `PYTHONPATH=$PWD pytest tests/unit/test_metrics_status.py::test_metrics_fields -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ec25cda08328962372d0c6b6e0e5