### PR TITLE
Run black formatter to satisfy lint check

### DIFF
--- a/src/core/agent_graph.py
+++ b/src/core/agent_graph.py
@@ -5,6 +5,7 @@ from langgraph.graph import END, StateGraph
 
 from src.agents.base_agent import AgentConfig
 from src.agents.developer_agent import DeveloperAgent
+
 # 기존 에이전트 import (실제 구현 연결 필요)
 from src.agents.planner_agent import PlannerAgent
 from src.agents.reviewer_agent import ReviewerAgent

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,9 +5,14 @@ from typing import Dict, List
 import pytest
 from fastapi.testclient import TestClient
 
-from palantir.core.agents.base import (AgentResult, AgentTask, DeveloperAgent,
-                                       PlannerAgent, ReviewerAgent,
-                                       SelfImproverAgent)
+from palantir.core.agents.base import (
+    AgentResult,
+    AgentTask,
+    DeveloperAgent,
+    PlannerAgent,
+    ReviewerAgent,
+    SelfImproverAgent,
+)
 from palantir.main import app
 from palantir.services.mcp.base import MCPContext, MCPResponse
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -47,6 +47,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+
 # DataPipeline 단위 테스트 (main)
 import pytest
 

--- a/tests/unit/test_weaviate_store.py
+++ b/tests/unit/test_weaviate_store.py
@@ -1,5 +1,8 @@
-from palantir.core.weaviate_store import (_memory_store, get_data_by_job_id,
-                                          store_to_weaviate)
+from palantir.core.weaviate_store import (
+    _memory_store,
+    get_data_by_job_id,
+    store_to_weaviate,
+)
 
 
 def test_store_and_get():


### PR DESCRIPTION
## Summary
- run `black` on `src/` and `tests/` to satisfy lint workflow

## Testing
- `black src/ tests/ --check`
- `pytest tests/unit/test_weaviate_store.py -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_684f9c91b7b88328ac75d6516af91379