### PR TITLE
Add docs index and dependency install helper

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Documentation Overview
+
+이 디렉터리에는 Palantir 프로젝트와 관련된 주요 문서가 정리되어 있습니다. 아래 표를 통해 각 문서의 용도와 간단한 설명을 확인할 수 있습니다.
+
+| 파일 | 설명 |
+|------|------|
+| `API_REFERENCE.md` | REST API 엔드포인트와 사용 예시 정리 |
+| `DEVLOG.md` | 개발 로그 및 향후 계획 기록 |
+| `FAQ.md` | 자주 묻는 질문과 답변 |
+| `FEATURE_PRD.md` | 제품 요구사항(PRD) 요약 |
+| `POLICY.md` | 운영 및 보안 정책 |
+| `USAGE_EXAMPLES.md` | 기능별 사용 예시 모음 |
+| `deployment.md` | 배포 가이드 |
+| `grafana_setup_win.md` | Windows 기반 Grafana 설정 방법 |
+| `progress_report_2025-06-05.md` | 2025-06-05 진행 상황 보고서 |
+| `troubleshooting.md` | 문제 해결 가이드 |
+| `user_management.md` | 사용자 관리 시스템 문서 |
+
+문서 수가 많아 처음 접하는 사용자가 원하는 정보를 찾기 어려울 수 있어 간략한 목차 역할을 하는 이 파일을 추가했습니다. 필요 시 새 문서를 작성하면 여기에도 항목을 추가해 주세요.

--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+REQ = ROOT / "requirements.txt"
+DEPS = ROOT / "deps"
+
+if not REQ.exists():
+    print("requirements.txt not found", file=sys.stderr)
+    sys.exit(1)
+
+cmd = [sys.executable, "-m", "pip", "install"]
+if DEPS.exists():
+    cmd += ["--no-index", "--find-links", str(DEPS), "-r", str(REQ), "--extra-index-url", f"file://{DEPS.resolve()}"]
+else:
+    cmd += ["-r", str(REQ)]
+
+print("Running:", " ".join(cmd))
+subprocess.check_call(cmd)


### PR DESCRIPTION
## Summary
- add `install_dependencies.py` script for installing from requirements
- create `docs/README.md` to give an overview of documents

## Testing
- `pip install pyyaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685153dd4f688328b94fc06dad1bac22