### PR TITLE
Add RAG pipeline with ML predictions

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from neo4j import GraphDatabase
 
 from palantir.api.ask import router as ask_router
+from palantir.api.qa import router as qa_router
 from palantir.api.metrics import router as metrics_router
 from palantir.api.ontology import router as ontology_router
 from palantir.api.pipeline import router as pipeline_router
@@ -37,6 +38,7 @@ setup_monitoring(app)
 # 라우터 등록
 app.include_router(pipeline_router)
 app.include_router(ask_router)
+app.include_router(qa_router)
 app.include_router(ontology_router)
 app.include_router(auth_router)
 app.include_router(metrics_router)

--- a/models/predict.py
+++ b/models/predict.py
@@ -1,0 +1,10 @@
+import mlflow
+import pandas as pd
+
+
+def predict(features: dict, model_uri: str = "model"):
+    """Load latest MLflow model and return prediction."""
+    model = mlflow.pyfunc.load_model(model_uri)
+    df = pd.DataFrame([features])
+    pred = model.predict(df)
+    return pred[0]

--- a/models/train.py
+++ b/models/train.py
@@ -1,0 +1,23 @@
+import mlflow
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score
+
+
+def train(data: pd.DataFrame, label: str, experiment: str = "default") -> float:
+    """Train a simple classifier and log to MLflow."""
+    mlflow.set_experiment(experiment)
+    with mlflow.start_run():
+        X = data.drop(columns=[label])
+        y = data[label]
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.2, random_state=42
+        )
+        clf = LogisticRegression(max_iter=1000)
+        clf.fit(X_train, y_train)
+        preds = clf.predict(X_test)
+        acc = accuracy_score(y_test, preds)
+        mlflow.log_metric("accuracy", acc)
+        mlflow.sklearn.log_model(clf, "model")
+        return acc

--- a/palantir/api/qa.py
+++ b/palantir/api/qa.py
@@ -1,0 +1,47 @@
+from typing import Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from langchain.vectorstores import Chroma
+from langchain.embeddings import SentenceTransformerEmbeddings
+from chromadb import Client
+from chromadb.config import Settings
+
+from palantir.services.mcp.llm_mcp import LLMMCP
+from models.predict import predict
+
+router = APIRouter()
+
+EMBED_MODEL = "all-MiniLM-L6-v2"
+chroma_client = Client(
+    Settings(persist_directory="./data/chroma_db", anonymized_telemetry=False)
+)
+embedding = SentenceTransformerEmbeddings(model_name=EMBED_MODEL)
+vectorstore = Chroma(
+    client=chroma_client, collection_name="project_docs", embedding_function=embedding
+)
+
+llm = LLMMCP()
+
+
+class QARequest(BaseModel):
+    question: str
+    features: Optional[Dict] = None
+
+
+@router.post("/qa")
+async def qa(request: QARequest):
+    """Vector search + LLM + ML 예측을 통합한 QA 엔드포인트."""
+    try:
+        answer = llm.retrieval_qa(request.question, vectorstore)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    prediction = None
+    if request.features:
+        try:
+            prediction = predict(request.features)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"ML prediction failed: {e}")
+
+    return {"answer": answer, "prediction": prediction}

--- a/palantir/services/mcp/llm_mcp.py
+++ b/palantir/services/mcp/llm_mcp.py
@@ -42,3 +42,15 @@ class LLMMCP:
                 return f"[LLM 오류] {str(e)}"
         # TODO: Azure/로컬 등 확장
         return "(LLM 응답 예시)"
+
+    def retrieval_qa(self, question: str, vectorstore) -> str:
+        """주어진 벡터스토어에서 컨텍스트를 검색해 답변을 생성한다."""
+        from langchain.vectorstores.base import VectorStore
+
+        if not isinstance(vectorstore, VectorStore):
+            raise TypeError("vectorstore must be a langchain VectorStore")
+
+        docs = vectorstore.similarity_search(question, k=3)
+        context = "\n\n".join([d.page_content for d in docs])
+        prompt = f"Context:\n{context}\n\nQuestion: {question}"
+        return self.generate(prompt)

--- a/palantir/ui/app.py
+++ b/palantir/ui/app.py
@@ -13,11 +13,10 @@ from streamlit_option_menu import option_menu
 
 from palantir.analysis.analyzer import recommend_by_rules
 from palantir.analysis.recommender import recommend_with_news
-from palantir.ingest.feed_manager import (fetch_and_parse_feeds,
-                                          filter_news_by_ticker)
+from palantir.ingest.feed_manager import fetch_and_parse_feeds, filter_news_by_ticker
 from palantir.ingest.metrics_fetcher import fetch_metrics_by_ticker
 
-from .pages import chat, data_explorer, insights, ontology_viewer, settings
+from .pages import chat, data_explorer, insights, ontology_viewer, settings, qa
 
 # 피드백 로그 파일 경로
 FEEDBACK_LOG = os.path.abspath(
@@ -80,18 +79,29 @@ def main():
             menu_title=None,
             options=[
                 "Chat Assistant",
+                "Retrieval QA",
                 "Data Explorer",
                 "Ontology Viewer",
                 "Insights",
                 "Settings",
             ],
-            icons=["chat-dots", "search", "diagram-3", "graph-up", "gear"],
+            icons=[
+                "chat-dots",
+                "question-circle",
+                "search",
+                "diagram-3",
+                "graph-up",
+                "gear",
+            ],
             default_index=0,
         )
 
     # Main content
     if selected == "Chat Assistant":
         chat.render_page()
+
+    elif selected == "Retrieval QA":
+        qa.render_page()
 
     elif selected == "Data Explorer":
         data_explorer.render_page()

--- a/palantir/ui/pages/qa.py
+++ b/palantir/ui/pages/qa.py
@@ -1,0 +1,19 @@
+import requests
+import streamlit as st
+
+API_URL = "http://localhost:8000/qa"
+
+
+def render_page():
+    st.title("Retrieval QA")
+    question = st.text_input("Question")
+    if st.button("Ask") and question:
+        with st.spinner("Querying..."):
+            resp = requests.post(API_URL, json={"question": question})
+            if resp.status_code == 200:
+                data = resp.json()
+                st.write(data.get("answer"))
+                if data.get("prediction") is not None:
+                    st.write(f"Prediction: {data['prediction']}")
+            else:
+                st.error("Request failed")

--- a/tests/test_rag_integration.py
+++ b/tests/test_rag_integration.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+from langchain.vectorstores import Chroma
+from langchain.embeddings import SentenceTransformerEmbeddings
+from chromadb import Client
+from chromadb.config import Settings
+
+from main import app
+import palantir.api.qa as qa_module
+
+
+def test_rag_answer_contains_context(tmp_path, monkeypatch):
+    client = Client(
+        Settings(persist_directory=str(tmp_path), anonymized_telemetry=False)
+    )
+    embedding = SentenceTransformerEmbeddings(model_name="all-MiniLM-L6-v2")
+    store = Chroma(client=client, collection_name="test", embedding_function=embedding)
+    store.add_texts(["The capital of France is Paris."], metadatas=[{"id": 1}])
+
+    monkeypatch.setattr(qa_module, "vectorstore", store)
+
+    api = TestClient(app)
+    resp = api.post("/qa", json={"question": "What is the capital of France?"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "Paris" in data["answer"]


### PR DESCRIPTION
## Summary
- implement retrieval_qa helper in LLMMCP
- add `/qa` API endpoint using vector search + ML predictions
- create simple ML training and prediction modules
- wire Streamlit to call Retrieval QA
- add integration test for QA workflow

## Testing
- `black palantir/api/qa.py palantir/services/mcp/llm_mcp.py palantir/ui/app.py palantir/ui/pages/qa.py main.py models/*.py tests/test_rag_integration.py`
- `pytest -k "rag_answer_contains_context" -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68517a298f808328b50081bc25f8966a